### PR TITLE
Fix incorrect intent-extra key

### DIFF
--- a/checkappsubscriptionexample/app/src/main/java/com/example/checkappsubscriptionexample/MainActivity.java
+++ b/checkappsubscriptionexample/app/src/main/java/com/example/checkappsubscriptionexample/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends Activity {
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
-    if (requestCode == RESULT_CODE && resultCode == RESULT_OK && data != null && data.getExtras().getString(Intents.EXTRA_TARGET_SUBSCRIPTION_ID) == TARGET_SUBSCRIPTION) {
+    if (requestCode == RESULT_CODE && resultCode == RESULT_OK && data != null && data.getExtras().getString(Intents.EXTRA_RESULT_SUBSCRIPTION_ID) == TARGET_SUBSCRIPTION) {
       Toast.makeText(this, "Upgraded", Toast.LENGTH_SHORT).show();
     } else {
       Toast.makeText(this, "Not Upgraded", Toast.LENGTH_SHORT).show();

--- a/checkappsubscriptionexample/app/src/main/java/com/example/checkappsubscriptionexample/MainActivity.java
+++ b/checkappsubscriptionexample/app/src/main/java/com/example/checkappsubscriptionexample/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends Activity {
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
-    if (requestCode == RESULT_CODE && resultCode == RESULT_OK && data != null && data.getExtras().getString(Intents.EXTRA_RESULT_SUBSCRIPTION_ID) == TARGET_SUBSCRIPTION) {
+    if (requestCode == RESULT_CODE && resultCode == RESULT_OK && data != null && TARGET_SUBSCRIPTION.equals(data.getExtras().getString(Intents.EXTRA_RESULT_SUBSCRIPTION_ID))) {
       Toast.makeText(this, "Upgraded", Toast.LENGTH_SHORT).show();
     } else {
       Toast.makeText(this, "Not Upgraded", Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
When receiving the result from the Clover App Market to upgrade the user's current subscription, we were erroneously checking for the Intents.EXTRA_TARGET_SUBSCRIPTION_ID string-extra. We need to check for Intents.EXTRA_RESULT_SUBSCRIPTION_ID.
